### PR TITLE
Replace with arxiv and link FAQ in 5/28 post

### DIFF
--- a/_posts/2021-05-28-census-das/census-das.Rmd
+++ b/_posts/2021-05-28-census-das/census-das.Rmd
@@ -44,7 +44,9 @@ for real-world purposes.  The ALARM project has conducted an extensive analysis
 into how the DAS-protected data affects redistricting and voting rights analyses,
 and has submitted these findings to the Census Bureau.
 
-**Read the report: *[The Impact of the U.S. Census Disclosure Avoidance System on Redistricting and Voting Rights Analysis](Harvard-DAS-Evaluation.pdf)***
+**Read the report: *[The Impact of the U.S. Census Disclosure Avoidance System on Redistricting and Voting Rights Analysis](https://arxiv.org/abs/2105.14197)***
+
+**Also see: [Answers to Frequently Asked Questions](https://alarm-redist.github.io/posts/2021-06-02-das-evaluation-faq/) Added on June 2, 2021.**
 
 ![A figure from the report, indicating partisan biases in the DAS-protected data.](ex_plot.png){width=100% .external}
 


### PR DESCRIPTION
It would be nice for new site visitors to see the most recent version of the paper and the FAQ + replies. If it is ok to retroactively add a line to a post, that is. 

If so we could also

- Add links to additional replies and FAQs to this post as they get posted
- Delete the PDF in the repo